### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/mrp2_analyzer/src/mrp2_analyzer.cpp
+++ b/mrp2_analyzer/src/mrp2_analyzer.cpp
@@ -3,9 +3,8 @@
 using namespace diagnostic_aggregator;
 using namespace std;
 
-PLUGINLIB_REGISTER_CLASS(MRP2Analyzer,  
-                         diagnostic_aggregator::MRP2Analyzer, 
-                         diagnostic_aggregator::Analyzer)
+PLUGINLIB_EXPORT_CLASS(diagnostic_aggregator::MRP2Analyzer,
+                       diagnostic_aggregator::Analyzer)
 
 MRP2Analyzer::MRP2Analyzer() :
   l_motor_path_(""), r_motor_path_(""), battery_path_(""), lights_path_(""), power_board_name_(""), 


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions